### PR TITLE
fix: import error (#21)

### DIFF
--- a/launch/unitree_driver_launch.py
+++ b/launch/unitree_driver_launch.py
@@ -3,36 +3,43 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.conditions import IfCondition
 from launch_ros.actions import Node
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, NotEqualsSubstitution
-from launch.actions import OpaqueFunction
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
     pkg_dir = get_package_share_directory("unitree_ros")
     default_param_file = os.path.join(pkg_dir, "config", "params.yaml")
     params_file_arg = DeclareLaunchArgument(
-        "params_file", default_value=str(default_param_file)
+        "params_file",
+        default_value=str(default_param_file),
+        description="Parameters file to be used.",
     )
-    robot_ip_arg = DeclareLaunchArgument("robot_ip", default_value=str(""))
+    use_wifi_arg = DeclareLaunchArgument(
+        "wifi",
+        default_value="false",
+        description="Uses the wifi IP for communicating with the robot",
+    )
 
     return LaunchDescription(
-        [params_file_arg, robot_ip_arg, launch_unitree_driver()]
+        [params_file_arg, use_wifi_arg, OpaqueFunction(function=launch_unitree_driver)]
     )
 
 
-def launch_unitree_driver():
+def launch_unitree_driver(context):
     params_file = LaunchConfiguration("params_file")
-    robot_ip = LaunchConfiguration("robot_ip")
+    wifi = context.launch_configurations.get("wifi", "false")
+    if wifi == "true":
+        robot_ip = "192.168.12.1"
+    else:
+        robot_ip = "192.168.123.161"
 
     unitree_driver_node = Node(
         package="unitree_ros",
         executable="unitree_driver",
         parameters=[params_file, {"robot_ip": robot_ip}],
         output="screen",
-        condition=IfCondition(NotEqualsSubstitution(robot_ip, "")),
     )
 
-    return unitree_driver_node
+    return [unitree_driver_node]


### PR DESCRIPTION
This commit fixes issue (#21) and changes the way we use the launch file. Now we only need to use wifi:=true instead of passing the robot ip.

In addition, when not passing the flag robot_ip for a non Wi-Fi connection, due to the default value being empty, the connection could not be established.