### PR TITLE
Feature: Publish Joint states of robot (#24)

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -10,6 +10,7 @@ unitree_ros_node:
     odom_topic_name: "/odom"
     imu_topic_name: "/imu"
     bms_state_topic_name: "/bms_state"
+    joint_states_topic_name: "/joint_states"
     # Frame Ids
     imu_frame_id: "imu"
     odom_frame_id: "odom"

--- a/include/unitree_ros/serializers.hpp
+++ b/include/unitree_ros/serializers.hpp
@@ -30,10 +30,13 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #ifndef SERIALIZERS_HPP
 #define SERIALIZERS_HPP
 
+#include <unitree_legged_sdk/comm.h>
+
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <unitree_ros/common_defines.hpp>
 #include <unitree_ros/msg/bms_state.hpp>
 #include <unitree_ros/msg/sensor_ranges.hpp>
@@ -44,5 +47,7 @@ void serialize(nav_msgs::msg::Odometry& msg, const odom_t odom);
 void serialize(sensor_msgs::msg::Imu& msg, const UNITREE_LEGGED_SDK::IMU imu);
 void serialize(unitree_ros::msg::BmsState& msg, const UNITREE_LEGGED_SDK::BmsState bms);
 void serialize(unitree_ros::msg::SensorRanges& msg, const sensor_ranges_t ranges);
+void serialize(sensor_msgs::msg::JointState& msg,
+               const std::array<UNITREE_LEGGED_SDK::MotorState, 12> motor_states);
 
 #endif  // !#ifndef SERIALIZERS_HPP

--- a/include/unitree_ros/unitree_driver.hpp
+++ b/include/unitree_ros/unitree_driver.hpp
@@ -33,6 +33,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #include <FaceLightClient.h>
 #include <unitree_legged_sdk/unitree_legged_sdk.h>
 
+#include <array>
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -148,6 +149,18 @@ class UnitreeDriver {
      * @return UNITREE_LEGGED_SDK::BMS: The BMS data from the robot
      */
     UNITREE_LEGGED_SDK::BmsState get_bms();
+
+    /**
+     * @brief Retrieves the state of each joint of the robot
+     *
+     *
+     * @return std::array<UNITREE_LEGGED_SDK::MotorState, 20>: The joint states of the
+     * robot. [ fr_hip, fr_tight, fr_calf,
+     *          fl_hip, fl_tight, fl_calf,
+     *          br_hip, br_tight, br_calf,
+     *          bl_hip, bl_tight, bl_calf ]
+     */
+    std::array<UNITREE_LEGGED_SDK::MotorState, 12> get_joint_states();
 
     /**
      * @brief Retrieves the distances comming from the radar sensors from the front and

--- a/include/unitree_ros/unitree_ros.hpp
+++ b/include/unitree_ros/unitree_ros.hpp
@@ -36,8 +36,10 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #include <geometry_msgs/msg/twist.hpp>
 #include <memory>
 #include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/empty.hpp>
 #include <std_msgs/msg/u_int8_multi_array.hpp>
 #include <unitree_ros/msg/bms_state.hpp>
@@ -60,6 +62,7 @@ class UnitreeRosNode : public rclcpp::Node {
     std::string imu_topic_name_ = ns_ + "/imu";
     std::string bms_topic_name_ = ns_ + "/bms";
     std::string sensor_ranges_topic_name = ns_ + "/sensor_ranges";
+    std::string joint_states_topic_name = ns_ + "/joint_states";
 
     // Frame Ids
     std::string odom_frame_id_ = ns_ + "odom";
@@ -71,6 +74,7 @@ class UnitreeRosNode : public rclcpp::Node {
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
     rclcpp::Publisher<unitree_ros::msg::BmsState>::SharedPtr bms_pub_;
     rclcpp::Publisher<unitree_ros::msg::SensorRanges>::SharedPtr sensor_ranges_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_states_pub_;
 
     // Subscriptions
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
@@ -126,6 +130,7 @@ class UnitreeRosNode : public rclcpp::Node {
     void publish_bms_();
     void publish_sensor_ranges_();
     void publish_odom_tf_(rclcpp::Time time, odom_t odom);
+    void publish_joint_states_(rclcpp::Time time);
 
     void apply_namespace_to_topic_names_();
 };

--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -101,7 +101,7 @@ void serialize(sensor_msgs::msg::JointState& msg,
     msg.velocity.resize(num_joints);
     msg.effort.resize(num_joints);
 
-    for (int leg = 0; leg < 4; leg++) {
+    for (int leg = 0; leg < num_joints; leg += 3) {
         for (int joint = 0; joint < 3; joint++) {
             int idx = leg + joint;
             msg.position[idx] = motor_states[idx].q;

--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -27,6 +27,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 */
 
+#include <iostream>
 #include <unitree_ros/serializers.hpp>
 
 void serialize(nav_msgs::msg::Odometry& msg, const odom_t odom) {
@@ -78,4 +79,34 @@ void serialize(unitree_ros::msg::SensorRanges& msg, const sensor_ranges_t radar)
     msg.front = radar.front;
     msg.left = radar.left;
     msg.right = radar.right;
+}
+
+void serialize(sensor_msgs::msg::JointState& msg,
+               const std::array<UNITREE_LEGGED_SDK::MotorState, 12> motor_states) {
+    msg.name = {"front_right_hip",
+                "front_right_tight",
+                "front_right_calf",
+                "front_left_hip",
+                "front_left_tight",
+                "front_left_calf",
+                "back_right_hip",
+                "back_right_tight",
+                "back_right_calf",
+                "back_left_hip",
+                "back_left_tight",
+                "back_left_calf"};
+
+    int num_joints = 12;
+    msg.position.resize(num_joints);
+    msg.velocity.resize(num_joints);
+    msg.effort.resize(num_joints);
+
+    for (int leg = 0; leg < 4; leg++) {
+        for (int joint = 0; joint < 3; joint++) {
+            int idx = leg + joint;
+            msg.position[idx] = motor_states[idx].q;
+            msg.velocity[idx] = motor_states[idx].dq;
+            msg.effort[idx] = motor_states[idx].tauEst;
+        }
+    }
 }

--- a/src/unitree_driver.cpp
+++ b/src/unitree_driver.cpp
@@ -29,6 +29,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 
 #include <unistd.h>
 
+#include <array>
 #include <cstdint>
 #include <iostream>
 #include <ostream>
@@ -95,6 +96,16 @@ sensor_ranges_t UnitreeDriver::get_radar_ranges() {
 UNITREE_LEGGED_SDK::IMU UnitreeDriver::get_imu() { return high_state_.imu; }
 
 UNITREE_LEGGED_SDK::BmsState UnitreeDriver::get_bms() { return high_state_.bms; }
+
+std::array<UNITREE_LEGGED_SDK::MotorState, 12> UnitreeDriver::get_joint_states() {
+    std::array<UNITREE_LEGGED_SDK::MotorState, 12> joint_states;
+
+    for (int i = 0; i < 12; i++) {
+        joint_states[i] = high_state_.motorState[i];
+    }
+
+    return joint_states;
+}
 
 uint8_t UnitreeDriver::get_battery_percentage() { return high_state_.bms.SOC; }
 

--- a/src/unitree_ros.cpp
+++ b/src/unitree_ros.cpp
@@ -104,6 +104,8 @@ void UnitreeRosNode::init_publishers_() {
     bms_pub_ = this->create_publisher<unitree_ros::msg::BmsState>(bms_topic_name_, qos);
     sensor_ranges_pub_ = this->create_publisher<unitree_ros::msg::SensorRanges>(
         sensor_ranges_topic_name, qos);
+    joint_states_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
+        joint_states_topic_name, qos);
 
     RCLCPP_INFO(get_logger(), "Finished initializing ROS publishers!");
 }
@@ -151,6 +153,7 @@ void UnitreeRosNode::robot_state_callback_() {
     publish_bms_();
     publish_sensor_ranges_();
     publish_odom_(now);
+    publish_joint_states_(now);
 }
 
 void UnitreeRosNode::cmd_vel_reset_callback_() {
@@ -224,6 +227,13 @@ void UnitreeRosNode::publish_odom_tf_(rclcpp::Time time, odom_t odom) {
     tf_broadcaster_->sendTransform(transform);
 }
 
+void UnitreeRosNode::publish_joint_states_(rclcpp::Time time) {
+    sensor_msgs::msg::JointState joint_state_msg;
+    joint_state_msg.header.stamp = time;
+    serialize(joint_state_msg, unitree_driver_->get_joint_states());
+    joint_states_pub_->publish(joint_state_msg);
+}
+
 // -----------------------------------------------------------------------------
 // -                              ROS Parameters                               -
 // -----------------------------------------------------------------------------
@@ -248,11 +258,13 @@ void UnitreeRosNode::read_parameters_() {
     declare_parameter<std::string>("imu_topic_name", imu_topic_name_);
     declare_parameter<std::string>("odom_topic_name", odom_topic_name_);
     declare_parameter<std::string>("bms_state_topic_name", bms_topic_name_);
+    declare_parameter<std::string>("joint_states_topic_name", joint_states_topic_name);
     // --------------------------------------------------------
     get_parameter("cmd_vel_topic_name", cmd_vel_topic_name_);
     get_parameter("odom_topic_name", odom_topic_name_);
     get_parameter("imu_topic_name", imu_topic_name_);
     get_parameter("bms_state_topic_name", bms_topic_name_);
+    get_parameter("joint_states_topic_name", joint_states_topic_name);
 
     // Frame Ids
     declare_parameter<std::string>("imu_frame_id", imu_frame_id_);


### PR DESCRIPTION
This PR, publishes the joint states of the robot, by default to `/joint_states`.
(#24)

## TODO:
- [x] Verify that each joint corresponds to the good leg and joint
- [x] Create parameters on parameters file