### PR TITLE
get_quaternion function is fixed according to sdk

### DIFF
--- a/src/unitree_driver.cpp
+++ b/src/unitree_driver.cpp
@@ -213,10 +213,10 @@ position_t UnitreeDriver::get_position_() {
 }
 
 quarternion_t UnitreeDriver::get_quaternion_() {
-    return {high_state_.imu.quaternion[0],
-            high_state_.imu.quaternion[1],
+    return {high_state_.imu.quaternion[1],
             high_state_.imu.quaternion[2],
-            high_state_.imu.quaternion[3]};
+            high_state_.imu.quaternion[3],
+            high_state_.imu.quaternion[0]};
 }
 
 velocity_t UnitreeDriver::get_velocity_() {


### PR DESCRIPTION
get_quaternion function is fixed according to https://unitree-docs.readthedocs.io/en/latest/get_started/Go1_Edu.html#go1-sdk-highstate-imu

![image](https://github.com/user-attachments/assets/12983004-19f8-430b-b80a-820861517524)
