### PR TITLE
fix[build]: fixed build issues with ros2 kilted in cmakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(unitree_ros)
 
 # Default to C99
@@ -8,7 +8,7 @@ endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -79,12 +79,39 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 # -    Build Section    -
 # -----------------------
 
+# NOTE This part is incompatible with newer ROS2 versions (e.g., kilted)
+# add_executable(unitree_driver src/unitree_ros_node.cpp ${SOURCES})
+# ament_target_dependencies(unitree_driver ${DEPENDENCIES})
+# rosidl_get_typesupport_target(cpp_typesupport_target
+#   ${PROJECT_NAME} rosidl_typesupport_cpp)
+# target_link_libraries(unitree_driver "${cpp_typesupport_target}" ${EXTRA_LIBS})
 
-add_executable(unitree_driver src/unitree_ros_node.cpp ${SOURCES})
-ament_target_dependencies(unitree_driver ${DEPENDENCIES})
-rosidl_get_typesupport_target(cpp_typesupport_target
-  ${PROJECT_NAME} rosidl_typesupport_cpp)
-target_link_libraries(unitree_driver "${cpp_typesupport_target}" ${EXTRA_LIBS})
+# NOTE This part makes the package build with newer ROS2 versions
+add_executable(unitree_driver
+  src/unitree_ros_node.cpp
+  ${SOURCES}
+)
+
+rosidl_get_typesupport_target(
+  cpp_typesupport_target
+  ${PROJECT_NAME}
+  rosidl_typesupport_cpp
+)
+
+target_link_libraries(unitree_driver PUBLIC
+  "${cpp_typesupport_target}"
+
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_ros::tf2_ros
+
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+
+  ${EXTRA_LIBS}
+)
 
 
 


### PR DESCRIPTION
# Fix ROS 2 Kilted Build Compatibility

## Summary

This PR updates the package build configuration to be compatible with newer ROS 2 distributions such as Kilted.

The package currently builds with a deprecation warning:

```text
ament_target_dependencies() is deprecated. Use target_link_libraries()
with modern CMake targets instead.
```

While the build succeeds, newer ROS 2 releases recommend linking against exported CMake targets directly instead of using `ament_target_dependencies()`.

## Changes

### Build System Modernization

* Increased minimum CMake version from `3.5` to `3.10`
* Updated the default C++ standard from `C++14` to `C++17`
* Replaced deprecated `ament_target_dependencies()` usage with modern CMake target linking
* Linked ROS dependencies using exported targets:

  * `rclcpp::rclcpp`
  * `tf2::tf2`
  * `tf2_ros::tf2_ros`
  * `${geometry_msgs_TARGETS}`
  * `${nav_msgs_TARGETS}`
  * `${sensor_msgs_TARGETS}`
  * `${std_msgs_TARGETS}`

### No Functional Changes

This PR does not modify runtime behavior. The changes are limited to the build system and dependency linkage.

## Motivation

Building the package on ROS 2 Kilted produces the following warning:

```text
ament_target_dependencies() is deprecated. Use target_link_libraries()
with modern CMake targets instead.
```

Migrating to modern CMake targets removes the deprecation warning and aligns the package with current ROS 2 build practices, improving forward compatibility with newer ROS 2 releases.

## Testing

### Build

Tested with:

```bash
colcon build --symlink-install
```

Result:

```text
Summary: 2 packages finished
```

The package builds successfully using the updated target-based dependency linkage.

### Hardware

Deployed on the Unitree Go1 Edu version. Works perfectly.