### PR TITLE
Low-Level Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(controller_manager REQUIRED)
+find_package(pluginlib REQUIRED)
 
 
 # --------------------------------
@@ -46,10 +49,11 @@ SET(EXTRA_LIBS
 SET(SOURCES 
     src/unitree_ros.cpp 
     src/unitree_driver.cpp 
+    src/unitree_driver_lowlevel.cpp
     src/serializers.cpp
 )
 
-SET(DEPENDENCIES rclcpp std_msgs nav_msgs sensor_msgs geometry_msgs tf2 tf2_ros)
+SET(DEPENDENCIES rclcpp std_msgs nav_msgs sensor_msgs geometry_msgs tf2 tf2_ros hardware_interface controller_manager pluginlib)
 
 # --------------------------------
 # -      Libraries Section       -
@@ -71,6 +75,11 @@ include_directories(include
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/BmsState.msg"
   "msg/SensorRanges.msg"
+  "msg/MotorCmd.msg"
+  "msg/MotorState.msg"
+  "msg/ImuState.msg"
+  "msg/LowCmd.msg"
+  "msg/LowState.msg"
   DEPENDENCIES builtin_interfaces std_msgs geometry_msgs sensor_msgs nav_msgs
 )
 
@@ -113,6 +122,43 @@ target_link_libraries(unitree_driver PUBLIC
   ${EXTRA_LIBS}
 )
 
+# Low-level driver node
+add_executable(unitree_lowlevel_driver
+  src/unitree_lowlevel_node.cpp
+  src/unitree_driver_lowlevel.cpp
+  src/serializers.cpp
+)
+
+target_link_libraries(unitree_lowlevel_driver PUBLIC
+  "${cpp_typesupport_target}"
+
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+
+  ${EXTRA_LIBS}
+)
+
+# ros2_control hardware interface plugin
+add_library(unitree_hardware_interface_lib SHARED
+  src/unitree_hardware_interface.cpp
+  src/unitree_driver_lowlevel.cpp
+  src/serializers.cpp
+)
+
+target_link_libraries(unitree_hardware_interface_lib PUBLIC
+  "${cpp_typesupport_target}"
+
+  rclcpp::rclcpp
+  hardware_interface::hardware_interface
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+
+  ${EXTRA_LIBS}
+)
+
+pluginlib_export_plugin_description_file(hardware_interface unitree_hardware_interface.xml)
+
 
 
 # -------------------
@@ -131,7 +177,11 @@ install(
 
 install(TARGETS 
   unitree_driver
-  DESTINATION lib/${PROJECT_NAME}
+  unitree_lowlevel_driver
+  unitree_hardware_interface_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
   INCLUDES DESTINATION include
 )
 

--- a/LOW_LEVEL_CONTROL_README.md
+++ b/LOW_LEVEL_CONTROL_README.md
@@ -1,0 +1,353 @@
+# Unitree Go1 Low-Level Control Guide
+
+This document describes how to use the low-level joint control capabilities for the Unitree Go1 quadruped robot in ROS2 (Jazzy/Kilted).
+
+## ⚠️ Safety First
+
+**READ THIS BEFORE RUNNING ANY LOW-LEVEL CONTROL:**
+
+1. **Robot must be suspended/harnessed** - The robot MUST be off the ground (hanging in a harness) before enabling low-level control
+2. **Pre-condition sequence required:**
+   - Press `L2 + A` on the remote to make the robot sit down
+   - Press `L1 + L2 + Start` to enter low-level control mode
+   - Verify the robot is in damping mode (limp) before sending commands
+3. **Start in damping mode** - Always begin with `kp=0, kd=5` before sending position commands
+4. **Joint limits** (from Unitree SDK):
+   - Hip: ±1.047 rad (±60°)
+   - Thigh: -0.663 to 2.966 rad (-38° to 170°)
+   - Calf: -2.721 to -0.837 rad (-156° to -48°)
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        ROS2 Control Stack                        │
+│  ┌─────────────────┐    ┌──────────────────┐    ┌────────────┐  │
+│  │ Joint Trajectory│───▶│  Hardware        │───▶│  Unitree   │  │
+│  │   Controller    │    │  Interface       │    │  LowLevel  │  │
+│  └─────────────────┘    └──────────────────┘    │  Driver    │  │
+│         ▲                       ▲               └──────┬─────┘  │
+│         │                       │                      │        │
+│         │              ┌────────┴────────┐             │        │
+│         │              │  Controller     │             ▼        │
+│         └──────────────│    Manager      │      UDP (500Hz)     │
+│                        └─────────────────┘         │            │
+└────────────────────────────────────────────────────┼────────────┘
+                                                     ▼
+                                            ┌─────────────────┐
+                                            │  Unitree Go1    │
+                                            │  (LOWLEVEL UDP) │
+                                            └─────────────────┘
+```
+
+---
+
+## Installation
+
+```bash
+# Build the workspace
+cd ~/ros2_ws
+colcon build --packages-select unitree_ros --cmake-args -DCMAKE_BUILD_TYPE=Release
+source install/setup.bash
+```
+
+### Docker builds (Jazzy & Kilted)
+
+Both distros are built in Docker and verified end-to-end:
+
+```bash
+# Jazzy
+docker build --network=host -f docker/jazzy/Dockerfile -t unitree_ros:jazzy .
+
+# Kilted
+docker build --network=host -f docker/kilted/Dockerfile -t unitree_ros:kilted .
+```
+
+Notes:
+- The Dockerfiles use `rosdep install --from-paths src`; the rosdep step runs its own `apt-get update` so that newly published packages are always picked up (avoids stale cached apt indexes).
+- `unitree_hardware_interface.xml` is copied into the image — it is required at configure time by `pluginlib_export_plugin_description_file` and referenced from `package.xml` via `${prefix}/unitree_hardware_interface.xml`.
+- The hardware plugin is exported under the category `hardware_interface`, not `unitree_ros`:
+  `pluginlib_export_plugin_description_file(hardware_interface unitree_hardware_interface.xml)`.
+  This is required so the `hardware_interface::SystemInterface` ClassLoader discovers it.
+
+---
+
+## Control Methods
+
+### Method 1: Direct Topic Control (Simple Testing)
+
+For quick testing without `ros2_control`:
+
+```bash
+# Terminal 1: Start low-level driver
+ros2 launch unitree_ros lowlevel.launch.py robot_ip:=192.168.123.161
+
+# Terminal 2: Send commands via custom topics (debugging only)
+ros2 topic pub /low_cmd unitree_ros/msg/LowCmd "motor_cmd: [...]"
+```
+
+**Topics:**
+- `/joint_states` - `sensor_msgs/JointState` (standard ROS joint states)
+- `/low_state` - `unitree_ros/msg/LowState` (full low-level state for debugging)
+
+---
+
+### Method 2: ros2_control + Standard Controllers (Recommended)
+
+This uses the standard ROS2 Control pipeline with `joint_trajectory_controller`.
+
+#### Launch the full stack:
+
+```bash
+# Terminal 1: Start hardware interface + controller manager + controllers
+ros2 launch unitree_ros lowlevel_ros2_control.launch.py robot_ip:=192.168.123.161
+```
+
+This starts:
+1. **Robot State Publisher** - Publishes the generated URDF to `/robot_description`
+2. **Hardware Interface** (`unitree_hardware_interface`) - Talks to robot via UDP
+3. **Controller Manager** (`ros2_control_node`) - Manages controllers
+4. **Joint State Broadcaster** - Publishes `/joint_states`
+5. **Joint Trajectory Controller** - Accepts trajectory commands
+
+The launch generates a minimal URDF inline with real `<joint>` elements (with Go1 joint limits), `<link>` elements, and the `<ros2_control>` hardware block. The controller manager on Jazzy/Kilted reads `robot_description` from the `/robot_description` **topic** (published by `robot_state_publisher`), not from a node parameter. The URDF `<joint>` elements are also required so `enforce_command_limits` can import the joint limits.
+
+#### Send joint trajectory commands:
+
+```bash
+# Send a trajectory to move joints
+ros2 topic pub /joint_trajectory_controller/joint_trajectory trajectory_msgs/msg/JointTrajectory "
+joint_names: ['FR_hip_joint', 'FR_thigh_joint', 'FR_calf_joint',
+              'FL_hip_joint', 'FL_thigh_joint', 'FL_calf_joint',
+              'RR_hip_joint', 'RR_thigh_joint', 'RR_calf_joint',
+              'RL_hip_joint', 'RL_thigh_joint', 'RL_calf_joint']
+points:
+  - positions: [0.0, 0.8, -1.5, 0.0, 0.8, -1.5, 0.0, 0.8, -1.5, 0.0, 0.8, -1.5]
+    velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    time_from_start: {sec: 2, nanosec: 0}
+"
+```
+
+#### Python example for sending trajectories:
+
+```python
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from builtin_interfaces.msg import Duration
+
+class TrajectorySender(Node):
+    def __init__(self):
+        super().__init__('trajectory_sender')
+        self.pub = self.create_publisher(
+            JointTrajectory, 
+            '/joint_trajectory_controller/joint_trajectory', 
+            10
+        )
+        self.timer = self.create_timer(1.0, self.send_trajectory)
+        self.joint_names = [
+            'FR_hip_joint', 'FR_thigh_joint', 'FR_calf_joint',
+            'FL_hip_joint', 'FL_thigh_joint', 'FL_calf_joint',
+            'RR_hip_joint', 'RR_thigh_joint', 'RR_calf_joint',
+            'RL_hip_joint', 'RL_thigh_joint', 'RL_calf_joint'
+        ]
+
+    def send_trajectory(self):
+        msg = JointTrajectory()
+        msg.joint_names = self.joint_names
+        
+        point = JointTrajectoryPoint()
+        # Stand pose (approximate)
+        point.positions = [0.0, 0.9, -1.8] * 4
+        point.velocities = [0.0] * 12
+        point.time_from_start = Duration(sec=3, nanosec=0)
+        
+        msg.points = [point]
+        self.pub.publish(msg)
+        self.get_logger().info('Sent trajectory')
+
+def main():
+    rclpy.init()
+    rclpy.spin(TrajectorySender())
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()
+```
+
+---
+
+### Method 3: Custom Controller (Advanced)
+
+For custom control algorithms, implement a `ros2_control` controller:
+
+```cpp
+// MyCustomController.hpp
+#include <controller_interface/controller_interface.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+
+class MyCustomController : public controller_interface::ControllerInterface
+{
+  // Implement update() to read state interfaces and write command interfaces
+};
+```
+
+Register in `plugin_description.xml` and load via controller manager.
+
+---
+
+## Joint Mapping
+
+| ROS Joint Name | SDK Index | Description |
+|----------------|-----------|-------------|
+| `FR_hip_joint` | 0 | Front Right Hip |
+| `FR_thigh_joint` | 1 | Front Right Thigh |
+| `FR_calf_joint` | 2 | Front Right Calf |
+| `FL_hip_joint` | 3 | Front Left Hip |
+| `FL_thigh_joint` | 4 | Front Left Thigh |
+| `FL_calf_joint` | 5 | Front Left Calf |
+| `RR_hip_joint` | 6 | Rear Right Hip |
+| `RR_thigh_joint` | 7 | Rear Right Thigh |
+| `RR_calf_joint` | 8 | Rear Right Calf |
+| `RL_hip_joint` | 9 | Rear Left Hip |
+| `RL_thigh_joint` | 10 | Rear Left Thigh |
+| `RL_calf_joint` | 11 | Rear Left Calf |
+
+---
+
+## Command Interfaces (per joint)
+
+The hardware interface exposes these standard command interfaces:
+
+| Interface | Description | Unit |
+|-----------|-------------|------|
+| `position` | Target position | rad |
+| `velocity` | Target velocity | rad/s |
+| `effort` | Feedforward torque | N⋅m |
+
+**Control Law:** `τ = kp × (q_target - q_current) + kd × (dq_target - dq_current) + τ_ff`
+
+The PD gains `kp` and `kd` are set globally via the `default_kp` / `default_kd` launch parameters (defaults: `60.0` and `3.0`).
+
+---
+
+## State Interfaces (per joint)
+
+| Interface | Description | Unit |
+|-----------|-------------|------|
+| `position` | Current position | rad |
+| `velocity` | Current velocity | rad/s |
+| `effort` | Estimated torque | N⋅m |
+
+---
+
+## Configuration
+
+### Launch Parameters (`lowlevel_ros2_control.launch.py`)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `robot_ip` | `192.168.123.161` | Robot IP address |
+| `robot_port` | `8082` | UDP port |
+| `default_kp` | `60.0` | Default position gain |
+| `default_kd` | `3.0` | Default velocity gain |
+
+The controller configuration is loaded from `config/unitree_ros_control.yaml` inside the installed package.
+
+### Controller Config (`config/unitree_ros_control.yaml`)
+
+Key settings:
+- `update_rate: 500` - Control loop frequency (must be 500Hz for Unitree)
+- `command_interfaces: [position, velocity]` - Active command types
+- `state_interfaces: [position, velocity, effort]` - Available state feedback
+
+---
+
+## Debugging Topics
+
+| Topic | Type | Description |
+|-------|------|-------------|
+| `/joint_states` | `sensor_msgs/JointState` | Standard joint states |
+| `/low_state` | `unitree_ros/msg/LowState` | Full low-level state (20 motors + IMU + BMS) |
+| `/controller_manager/controller_state` | `controller_manager_msgs/msg/ControllerState` | Controller status |
+
+---
+
+## Troubleshooting
+
+### "Cannot connect to robot"
+- Verify IP: `ping 192.168.123.161`
+- Check network interface: `ifconfig` (should have static IP on same subnet)
+- Ensure robot is powered on and in low-level mode (L1+L2+Start)
+
+The hardware interface refuses to initialize (`on_init` returns `ERROR`) when the robot IP is unreachable — this is intentional fail-fast behavior. The driver constructor pings the robot IP and throws if it is not reachable.
+
+### "Controller manager waits for 'robot_description' topic"
+- Since Jazzy/Kilted, `ros2_control_node` subscribes to the `/robot_description` **topic** instead of reading a `robot_description` parameter.
+- The launch file includes `robot_state_publisher`, which publishes the generated URDF with `transient_local` QoS. Do not remove it.
+
+### "Joint 'X' not found in URDF"
+- `enforce_command_limits` requires every joint in the `<ros2_control>` block to exist as a real `<joint>` element in the URDF (with a `<limit>` child).
+- The generated URDF in `lowlevel_ros2_control.launch.py` includes these joints and the Go1 limits (hip ±1.047 rad, thigh -0.663/2.966 rad, calf -2.721/-0.837 rad). If you write your own URDF, keep the `<joint>` elements.
+
+### "Joint trajectory controller not active"
+```bash
+# Check controller status
+ros2 control list_controllers
+
+# Manually activate if needed
+ros2 control set_controller_state joint_trajectory_controller active
+```
+
+### "Robot flails / moves unexpectedly"
+- **STOP IMMEDIATELY** (Ctrl+C)
+- Verify robot is suspended
+- Start in damping mode: `driver_->set_damping_mode()`
+- Check joint limits in your commands
+
+### "CRC errors / communication failures"
+- Ensure 500Hz control loop timing
+- Check UDP buffer sizes
+- Verify no other process using port 8082/8090
+
+### Jazzy only: `ros2_control_node` dies with a Fast CDR symbol error
+```
+ros2_control_node: symbol lookup error: libpal_statistics_msgs__rosidl_typesupport_fastrtps_cpp.so:
+  undefined symbol: _ZN8eprosima7fastcdr3Cdr9serializeEj
+```
+- This is an **upstream packaging issue** in the Jazzy apt repo (as of 2026-06): `pal_statistics_msgs` 2.7.0 was built against a Fast CDR ABI that provides `Cdr::serialize(unsigned int)`, but the installed `ros-jazzy-fastcdr` is 2.2.5, which only provides `Cdr::serialize(int)`.
+- It occurs even for a stock `ros2_control_node` with no Unitree code involved, and does **not** affect Kilted.
+- Tracking: ros2/rosidl_typesupport_fastrtps#126, eProsima/Fast-CDR#266.
+- Workarounds: run the stack on Kilted, or wait for the Jazzy packages to be rebuilt against a consistent Fast CDR.
+
+---
+
+## Performance Notes
+
+- **Control Loop**: 500Hz (2ms period) - hard real-time requirement
+- **UDP Latency**: <1ms typical on direct Ethernet
+- **Joint State Publish**: 500Hz (configurable via `publish_rate`)
+- **Recommended PC**: Ubuntu 22.04/24.04 with RT kernel for best performance
+
+---
+
+## Migration from High-Level Control
+
+| High-Level (Old) | Low-Level (New) |
+|------------------|-----------------|
+| `/cmd_vel` (Twist) | `/joint_trajectory_controller/joint_trajectory` |
+| `stand_up` / `stand_down` services | Trajectory to stand/sit poses |
+| `/joint_states` (from high_state) | `/joint_states` (from low_state - higher fidelity) |
+| Gait modes (trot, walk) | Custom trajectories or gait controllers |
+
+---
+
+## References
+
+- [Unitree Legged SDK v3.5.1](https://github.com/unitreerobotics/unitree_legged_sdk)
+- [ROS2 Control Documentation](https://control.ros.org/)
+- [Joint Trajectory Controller](https://control.ros.org/master/doc/ros2_controllers/joint_trajectory_controller/doc/userdoc.html)
+- [unitree_ros2_to_real](https://github.com/unitreerobotics/unitree_ros2_to_real) - Official low-level examples

--- a/config/unitree_ros_control.yaml
+++ b/config/unitree_ros_control.yaml
@@ -1,0 +1,84 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+joint_state_broadcaster:
+  ros__parameters:
+    update_rate: 500
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - FR_hip_joint
+      - FR_thigh_joint
+      - FR_calf_joint
+      - FL_hip_joint
+      - FL_thigh_joint
+      - FL_calf_joint
+      - RR_hip_joint
+      - RR_thigh_joint
+      - RR_calf_joint
+      - RL_hip_joint
+      - RL_thigh_joint
+      - RL_calf_joint
+    
+    command_interfaces:
+      - position
+      - velocity
+    
+    state_interfaces:
+      - position
+      - velocity
+      - effort
+    
+    update_rate: 500
+    
+    allow_partial_joints_goal: false
+    
+    open_loop_control: false
+    
+    allow_integration_in_goal_trajectories: true
+    
+    constraints:
+      stopped_velocity_tolerance: 0.01
+      goal_time: 0.0
+      FR_hip_joint:
+        trajectory: 0.1
+        goal: 0.1
+      FR_thigh_joint:
+        trajectory: 0.1
+        goal: 0.1
+      FR_calf_joint:
+        trajectory: 0.1
+        goal: 0.1
+      FL_hip_joint:
+        trajectory: 0.1
+        goal: 0.1
+      FL_thigh_joint:
+        trajectory: 0.1
+        goal: 0.1
+      FL_calf_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RR_hip_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RR_thigh_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RR_calf_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RL_hip_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RL_thigh_joint:
+        trajectory: 0.1
+        goal: 0.1
+      RL_calf_joint:
+        trajectory: 0.1
+        goal: 0.1

--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bbf0489..79a78d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ project(unitree_ros)
+ 
+ # Default to C99
+@@ -8,7 +8,7 @@ endif()
+ 
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 14)
++  set(CMAKE_CXX_STANDARD 17)
+ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+@@ -79,12 +79,39 @@ rosidl_generate_interfaces(${PROJECT_NAME}
+ # -    Build Section    -
+ # -----------------------
+ 
++# NOTE This part is incompatible with newer ROS2 versions (e.g., kilted)
++# add_executable(unitree_driver src/unitree_ros_node.cpp ${SOURCES})
++# ament_target_dependencies(unitree_driver ${DEPENDENCIES})
++# rosidl_get_typesupport_target(cpp_typesupport_target
++#   ${PROJECT_NAME} rosidl_typesupport_cpp)
++# target_link_libraries(unitree_driver "${cpp_typesupport_target}" ${EXTRA_LIBS})
++
++# NOTE This part makes the package build with newer ROS2 versions
++add_executable(unitree_driver
++  src/unitree_ros_node.cpp
++  ${SOURCES}
++)
++
++rosidl_get_typesupport_target(
++  cpp_typesupport_target
++  ${PROJECT_NAME}
++  rosidl_typesupport_cpp
++)
++
++target_link_libraries(unitree_driver PUBLIC
++  "${cpp_typesupport_target}"
+ 
+-add_executable(unitree_driver src/unitree_ros_node.cpp ${SOURCES})
+-ament_target_dependencies(unitree_driver ${DEPENDENCIES})
+-rosidl_get_typesupport_target(cpp_typesupport_target
+-  ${PROJECT_NAME} rosidl_typesupport_cpp)
+-target_link_libraries(unitree_driver "${cpp_typesupport_target}" ${EXTRA_LIBS})
++  rclcpp::rclcpp
++  tf2::tf2
++  tf2_ros::tf2_ros
++
++  ${geometry_msgs_TARGETS}
++  ${nav_msgs_TARGETS}
++  ${sensor_msgs_TARGETS}
++  ${std_msgs_TARGETS}
++
++  ${EXTRA_LIBS}
++)
+ 
+ 
+ 

--- a/docker/jazzy/Dockerfile
+++ b/docker/jazzy/Dockerfile
@@ -38,7 +38,8 @@ COPY CMakeLists.txt .
 # -----------------------------------------------------------------------------
 WORKDIR /root/unitree_ws
 
-RUN bash -c "\
+RUN apt-get update && \
+    bash -c "\
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
     rosdep update && \
     rosdep install \
@@ -64,6 +65,7 @@ COPY msg/ msg/
 COPY launch/ launch/
 COPY config/ config/
 COPY utils/ utils/
+COPY unitree_hardware_interface.xml .
 
 # -----------------------------------------------------------------------------
 # Build workspace

--- a/docker/jazzy/Dockerfile
+++ b/docker/jazzy/Dockerfile
@@ -1,0 +1,85 @@
+FROM ros:jazzy-ros-base
+
+# -----------------------------------------------------------------------------
+# Environment
+# -----------------------------------------------------------------------------
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=jazzy
+
+# -----------------------------------------------------------------------------
+# Install system dependencies
+# -----------------------------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        iputils-ping \
+        libboost-all-dev \
+        libtool \
+        nano \
+        python3 \
+        python3-pip \
+        python3-vcstool \
+        vim \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# Create workspace
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws/src/unitree_ros
+
+# Copy only dependency manifests first to maximize Docker cache reuse.
+COPY package.xml .
+COPY CMakeLists.txt .
+
+# -----------------------------------------------------------------------------
+# Install ROS dependencies
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws
+
+RUN bash -c "\
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    rosdep update && \
+    rosdep install \
+        --from-paths src \
+        --ignore-src \
+        --rosdistro ${ROS_DISTRO} \
+        --reinstall \
+        -r \
+        -y \
+"
+
+# -----------------------------------------------------------------------------
+# Copy package sources
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws/src/unitree_ros
+
+COPY CHANGELOG.rst .
+COPY LICENSE .
+
+COPY include/ include/
+COPY src/ src/
+COPY msg/ msg/
+COPY launch/ launch/
+COPY config/ config/
+COPY utils/ utils/
+
+# -----------------------------------------------------------------------------
+# Build workspace
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws
+
+RUN bash -c "\
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    colcon build \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release \
+"
+
+# -----------------------------------------------------------------------------
+# Automatically source ROS + workspace
+# -----------------------------------------------------------------------------
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.bash' >> /root/.bashrc && \
+    echo 'source /root/unitree_ws/install/setup.bash' >> /root/.bashrc
+
+CMD ["bash"]

--- a/docker/kilted/Dockerfile
+++ b/docker/kilted/Dockerfile
@@ -38,7 +38,8 @@ COPY CMakeLists.txt .
 # -----------------------------------------------------------------------------
 WORKDIR /root/unitree_ws
 
-RUN bash -c "\
+RUN apt-get update && \
+    bash -c "\
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
     rosdep update && \
     rosdep install \
@@ -64,6 +65,7 @@ COPY msg/ msg/
 COPY launch/ launch/
 COPY config/ config/
 COPY utils/ utils/
+COPY unitree_hardware_interface.xml .
 
 # -----------------------------------------------------------------------------
 # Build workspace

--- a/docker/kilted/Dockerfile
+++ b/docker/kilted/Dockerfile
@@ -1,0 +1,85 @@
+FROM ros:kilted-ros-base
+
+# -----------------------------------------------------------------------------
+# Environment
+# -----------------------------------------------------------------------------
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=kilted
+
+# -----------------------------------------------------------------------------
+# Install system dependencies
+# -----------------------------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        iputils-ping \
+        libboost-all-dev \
+        libtool \
+        nano \
+        python3 \
+        python3-pip \
+        python3-vcstool \
+        vim \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# Create workspace
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws/src/unitree_ros
+
+# Copy only dependency manifests first to maximize Docker cache reuse.
+COPY package.xml .
+COPY CMakeLists.txt .
+
+# -----------------------------------------------------------------------------
+# Install ROS dependencies
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws
+
+RUN bash -c "\
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    rosdep update && \
+    rosdep install \
+        --from-paths src \
+        --ignore-src \
+        --rosdistro ${ROS_DISTRO} \
+        --reinstall \
+        -r \
+        -y \
+"
+
+# -----------------------------------------------------------------------------
+# Copy package sources
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws/src/unitree_ros
+
+COPY CHANGELOG.rst .
+COPY LICENSE .
+
+COPY include/ include/
+COPY src/ src/
+COPY msg/ msg/
+COPY launch/ launch/
+COPY config/ config/
+COPY utils/ utils/
+
+# -----------------------------------------------------------------------------
+# Build workspace
+# -----------------------------------------------------------------------------
+WORKDIR /root/unitree_ws
+
+RUN bash -c "\
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    colcon build \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release \
+"
+
+# -----------------------------------------------------------------------------
+# Automatically source ROS + workspace
+# -----------------------------------------------------------------------------
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.bash' >> /root/.bashrc && \
+    echo 'source /root/unitree_ws/install/setup.bash' >> /root/.bashrc
+
+CMD ["bash"]

--- a/include/unitree_ros/serializers.hpp
+++ b/include/unitree_ros/serializers.hpp
@@ -38,8 +38,14 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <unitree_ros/common_defines.hpp>
+#include <unitree_ros/unitree_driver_lowlevel.hpp>
 #include <unitree_ros/msg/bms_state.hpp>
 #include <unitree_ros/msg/sensor_ranges.hpp>
+#include <unitree_ros/msg/low_cmd.hpp>
+#include <unitree_ros/msg/low_state.hpp>
+#include <unitree_ros/msg/motor_cmd.hpp>
+#include <unitree_ros/msg/motor_state.hpp>
+#include <unitree_ros/msg/imu_state.hpp>
 
 #include "unitree_legged_sdk/comm.h"
 
@@ -49,5 +55,12 @@ void serialize(unitree_ros::msg::BmsState& msg, const UNITREE_LEGGED_SDK::BmsSta
 void serialize(unitree_ros::msg::SensorRanges& msg, const sensor_ranges_t ranges);
 void serialize(sensor_msgs::msg::JointState& msg,
                const std::array<UNITREE_LEGGED_SDK::MotorState, 12> motor_states);
+
+void serialize(unitree_ros::msg::LowCmd& msg, const UnitreeDriverLowLevel::LowCmd& cmd);
+void serialize(unitree_ros::msg::LowState& msg, const UnitreeDriverLowLevel::LowState& state);
+void serialize(unitree_ros::msg::MotorCmd& msg, const UnitreeDriverLowLevel::MotorCommand& cmd);
+void serialize(unitree_ros::msg::MotorState& msg, const UnitreeDriverLowLevel::MotorState& state);
+void serialize(unitree_ros::msg::ImuState& msg, const UnitreeDriverLowLevel::ImuState& imu);
+void serialize(unitree_ros::msg::BmsState& msg, const UnitreeDriverLowLevel::BmsState& bms);
 
 #endif  // !#ifndef SERIALIZERS_HPP

--- a/include/unitree_ros/unitree_driver_lowlevel.hpp
+++ b/include/unitree_ros/unitree_driver_lowlevel.hpp
@@ -1,0 +1,108 @@
+#ifndef UNITREE_DRIVER_LOWLEVEL_H
+#define UNITREE_DRIVER_LOWLEVEL_H
+
+#include <unitree_legged_sdk/unitree_legged_sdk.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unitree_ros/common_defines.hpp>
+
+class UnitreeDriverLowLevel {
+ public:
+  struct MotorCommand {
+    uint8_t mode = 0x00;
+    float q = 0.0f;
+    float dq = 0.0f;
+    float tau = 0.0f;
+    float kp = 0.0f;
+    float kd = 0.0f;
+  };
+
+  struct MotorState {
+    uint8_t mode = 0;
+    float q = 0.0f;
+    float dq = 0.0f;
+    float ddq = 0.0f;
+    float tauEst = 0.0f;
+    float q_raw = 0.0f;
+    float dq_raw = 0.0f;
+    float ddq_raw = 0.0f;
+    int8_t temperature = 0;
+  };
+
+  struct ImuState {
+    std::array<float, 4> quaternion{};
+    std::array<float, 3> gyroscope{};
+    std::array<float, 3> accelerometer{};
+    std::array<float, 3> rpy{};
+    int8_t temperature = 0;
+  };
+
+  struct BmsState {
+    uint8_t version_h = 0;
+    uint8_t version_l = 0;
+    uint8_t bms_status = 0;
+    uint8_t SOC = 0;
+    int32_t current = 0;
+    uint16_t cycle = 0;
+    std::array<int8_t, 2> BQ_NTC{};
+    std::array<int8_t, 2> MCU_NTC{};
+    std::array<uint16_t, 10> cell_vol{};
+  };
+
+  struct LowState {
+    ImuState imu;
+    std::array<MotorState, 20> motorState;
+    BmsState bms;
+    std::array<int16_t, 4> footForce{};
+    std::array<int16_t, 4> footForceEst{};
+    uint32_t tick = 0;
+    std::array<uint8_t, 40> wirelessRemote{};
+  };
+
+  struct LowCmd {
+    std::array<MotorCommand, 20> motorCmd;
+    BmsState bms;
+    std::array<uint8_t, 40> wirelessRemote{};
+  };
+
+  explicit UnitreeDriverLowLevel(
+      std::string ip_addr = "192.168.123.161", int target_port = 8082);
+  ~UnitreeDriverLowLevel();
+
+  void send_low_cmd(const LowCmd& cmd);
+  LowState get_low_state() const;
+  std::array<MotorState, 12> get_leg_joint_states() const;
+  void set_damping_mode();
+  void set_position_mode(float kp = 60.0f, float kd = 3.0f);
+  bool is_connection_established() const;
+
+ private:
+  static constexpr int LOCAL_PORT = 8090;
+  static constexpr int NUM_LEG_JOINTS = 12;
+  static constexpr int NUM_TOTAL_MOTORS = 20;
+
+  std::string ip_addr_;
+  int target_port_;
+  UNITREE_LEGGED_SDK::UDP udp_connection_;
+  UNITREE_LEGGED_SDK::LowCmd sdk_low_cmd_{};
+  UNITREE_LEGGED_SDK::LowState sdk_low_state_{};
+
+  std::thread recv_state_thread_;
+  std::atomic<bool> recv_state_thread_stop_flag_{false};
+  std::atomic<bool> connection_established_{false};
+
+  std::array<int, 12> leg_joint_indices_ = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+  void recv_low_state_loop_();
+  bool is_connection_established_();
+  void init_cmd_data_();
+  uint32_t crc32_core_(const uint32_t* ptr, uint32_t len);
+  void compute_crc_(UNITREE_LEGGED_SDK::LowCmd& cmd);
+};
+
+#endif

--- a/include/unitree_ros/unitree_hardware_interface.hpp
+++ b/include/unitree_ros/unitree_hardware_interface.hpp
@@ -1,0 +1,68 @@
+#ifndef UNITREE_HARDWARE_INTERFACE_HPP
+#define UNITREE_HARDWARE_INTERFACE_HPP
+
+#include <hardware_interface/system_interface.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/state.hpp>
+#include <unitree_ros/unitree_driver_lowlevel.hpp>
+
+#include <array>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace unitree_ros
+{
+
+class UnitreeHardwareInterface : public hardware_interface::SystemInterface
+{
+public:
+  hardware_interface::CallbackReturn on_init(
+    const hardware_interface::HardwareInfo& info) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  hardware_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::return_type read(
+    const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  hardware_interface::return_type write(
+    const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+private:
+  std::unique_ptr<UnitreeDriverLowLevel> driver_;
+  std::string robot_ip_ = "192.168.123.161";
+  int robot_port_ = 8082;
+  float default_kp_ = 60.0f;
+  float default_kd_ = 3.0f;
+
+  std::vector<double> hw_positions_;
+  std::vector<double> hw_velocities_;
+  std::vector<double> hw_efforts_;
+  std::vector<double> hw_position_commands_;
+  std::vector<double> hw_velocity_commands_;
+  std::vector<double> hw_effort_commands_;
+
+  std::vector<std::string> joint_names_ = {
+    "FR_hip_joint", "FR_thigh_joint", "FR_calf_joint",
+    "FL_hip_joint", "FL_thigh_joint", "FL_calf_joint",
+    "RR_hip_joint", "RR_thigh_joint", "RR_calf_joint",
+    "RL_hip_joint", "RL_thigh_joint", "RL_calf_joint"
+  };
+
+  const std::array<int, 12> joint_to_sdk_index_ = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+  bool first_read_ = true;
+};
+
+}  // namespace unitree_ros
+
+#endif  // UNITREE_HARDWARE_INTERFACE_HPP

--- a/launch/lowlevel.launch.py
+++ b/launch/lowlevel.launch.py
@@ -1,0 +1,67 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    robot_ip_arg = DeclareLaunchArgument(
+        'robot_ip',
+        default_value='192.168.123.161',
+        description='IP address of the Unitree Go1 robot'
+    )
+    
+    robot_port_arg = DeclareLaunchArgument(
+        'robot_port',
+        default_value='8082',
+        description='UDP port for robot communication'
+    )
+    
+    publish_rate_arg = DeclareLaunchArgument(
+        'publish_rate',
+        default_value='500.0',
+        description='Publish rate in Hz for joint states and low state'
+    )
+    
+    joint_states_topic_arg = DeclareLaunchArgument(
+        'joint_states_topic',
+        default_value='joint_states',
+        description='Topic name for joint states'
+    )
+    
+    low_state_topic_arg = DeclareLaunchArgument(
+        'low_state_topic',
+        default_value='low_state',
+        description='Topic name for low-level state'
+    )
+
+    low_cmd_topic_arg = DeclareLaunchArgument(
+        'low_cmd_topic',
+        default_value='low_cmd',
+        description='Topic name for low-level commands'
+    )
+
+    lowlevel_driver_node = Node(
+        package='unitree_ros',
+        executable='unitree_lowlevel_driver',
+        name='unitree_lowlevel_driver',
+        output='screen',
+        parameters=[{
+            'robot_ip': LaunchConfiguration('robot_ip'),
+            'robot_port': LaunchConfiguration('robot_port'),
+            'publish_rate': LaunchConfiguration('publish_rate'),
+            'joint_states_topic': LaunchConfiguration('joint_states_topic'),
+            'low_state_topic': LaunchConfiguration('low_state_topic'),
+            'low_cmd_topic': LaunchConfiguration('low_cmd_topic'),
+        }]
+    )
+
+    return LaunchDescription([
+        robot_ip_arg,
+        robot_port_arg,
+        publish_rate_arg,
+        joint_states_topic_arg,
+        low_state_topic_arg,
+        low_cmd_topic_arg,
+        lowlevel_driver_node,
+    ])

--- a/launch/lowlevel_ros2_control.launch.py
+++ b/launch/lowlevel_ros2_control.launch.py
@@ -1,0 +1,148 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+import os
+
+
+# Go1 joint limits [rad]: hip, thigh, calf. Thigh/calf pitch axes are negative.
+JOINT_LIMITS = {
+    'hip': (-1.047, 1.047),
+    'thigh': (-0.663, 2.966),
+    'calf': (-2.721, -0.837),
+}
+LEGS = ['FR', 'FL', 'RR', 'RL']
+
+
+def generate_robot_description(robot_ip, robot_port, default_kp, default_kd):
+    """Generate a minimal URDF with links, revolute joints and the ros2_control
+    hardware block. Real <joint> elements are required because the controller
+    manager imports joint limits from the URDF (enforce_command_limits)."""
+    joint_xml = ""
+    control_joint_xml = ""
+    for leg in LEGS:
+        prev_link = 'base'
+        for i, (name, (lower, upper)) in enumerate(JOINT_LIMITS.items()):
+            joint = f"{leg}_{name}_joint"
+            link = f"{leg}_{name}_link"
+            axis = '0 0 1' if name == 'hip' else '0 1 0'
+            joint_xml += f"""
+    <joint name="{joint}" type="revolute">
+      <parent link="{prev_link}"/>
+      <child link="{link}"/>
+      <origin xyz="0 0 -0.02" rpy="0 0 0"/>
+      <axis xyz="{axis}"/>
+      <limit lower="{lower}" upper="{upper}" effort="33.5" velocity="25.0"/>
+    </joint>
+    <link name="{link}"/>"""
+            control_joint_xml += f"""
+    <joint name="{joint}">
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
+      <command_interface name="effort"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>"""
+            prev_link = link
+
+    robot_description = f"""<?xml version="1.0"?>
+<robot name="unitree_go1">
+  <link name="base"/>
+{joint_xml}
+  <ros2_control name="UnitreeHardwareInterface" type="system">
+    <hardware>
+      <plugin>unitree_ros/UnitreeHardwareInterface</plugin>
+      <param name="robot_ip">{robot_ip}</param>
+      <param name="robot_port">{robot_port}</param>
+      <param name="default_kp">{default_kp}</param>
+      <param name="default_kd">{default_kd}</param>
+    </hardware>
+{control_joint_xml}
+  </ros2_control>
+</robot>"""
+
+    return robot_description
+
+
+def launch_setup(context, *args, **kwargs):
+    robot_ip = LaunchConfiguration('robot_ip').perform(context)
+    robot_port = LaunchConfiguration('robot_port').perform(context)
+    default_kp = LaunchConfiguration('default_kp').perform(context)
+    default_kd = LaunchConfiguration('default_kd').perform(context)
+
+    robot_description = generate_robot_description(
+        robot_ip, robot_port, default_kp, default_kd)
+
+    controller_config_path = os.path.join(
+        get_package_share_directory('unitree_ros'),
+        'config', 'unitree_ros_control.yaml')
+
+    robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        name='robot_state_publisher',
+        output='screen',
+        parameters=[{'robot_description': robot_description}],
+    )
+
+    ros2_control_node = Node(
+        package='controller_manager',
+        executable='ros2_control_node',
+        name='controller_manager',
+        output='screen',
+        parameters=[{
+            'robot_description': robot_description,
+        }, controller_config_path],
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        name='joint_state_broadcaster_spawner',
+        arguments=['joint_state_broadcaster', '--controller-manager', '/controller_manager'],
+        output='screen',
+    )
+
+    joint_trajectory_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        name='joint_trajectory_controller_spawner',
+        arguments=['joint_trajectory_controller', '--controller-manager', '/controller_manager'],
+        output='screen',
+    )
+
+    return [robot_state_publisher, ros2_control_node, joint_state_broadcaster_spawner,
+            joint_trajectory_controller_spawner]
+
+
+def generate_launch_description():
+    robot_ip_arg = DeclareLaunchArgument(
+        'robot_ip',
+        default_value='192.168.123.161',
+        description='IP address of the Unitree Go1 robot')
+
+    robot_port_arg = DeclareLaunchArgument(
+        'robot_port',
+        default_value='8082',
+        description='UDP port for robot communication')
+
+    default_kp_arg = DeclareLaunchArgument(
+        'default_kp',
+        default_value='60.0',
+        description='Default position gain (Kp)')
+
+    default_kd_arg = DeclareLaunchArgument(
+        'default_kd',
+        default_value='3.0',
+        description='Default velocity gain (Kd)')
+
+    return LaunchDescription([
+        robot_ip_arg,
+        robot_port_arg,
+        default_kp_arg,
+        default_kd_arg,
+        OpaqueFunction(function=launch_setup),
+    ])

--- a/msg/ImuState.msg
+++ b/msg/ImuState.msg
@@ -1,0 +1,5 @@
+float32[4] quaternion
+float32[3] gyroscope
+float32[3] accelerometer
+float32[3] rpy
+int8 temperature

--- a/msg/LowCmd.msg
+++ b/msg/LowCmd.msg
@@ -1,0 +1,4 @@
+builtin_interfaces/Time stamp
+unitree_ros/MotorCmd[] motor_cmd
+unitree_ros/BmsState bms
+uint8[40] wireless_remote

--- a/msg/LowState.msg
+++ b/msg/LowState.msg
@@ -1,0 +1,8 @@
+builtin_interfaces/Time stamp
+unitree_ros/MotorState[] motor_state
+unitree_ros/ImuState imu
+unitree_ros/BmsState bms
+int16[4] foot_force
+int16[4] foot_force_est
+uint32 tick
+uint8[40] wireless_remote

--- a/msg/MotorCmd.msg
+++ b/msg/MotorCmd.msg
@@ -1,0 +1,6 @@
+uint8 mode
+float32 q
+float32 dq
+float32 tau
+float32 kp
+float32 kd

--- a/msg/MotorState.msg
+++ b/msg/MotorState.msg
@@ -1,0 +1,9 @@
+uint8 mode
+float32 q
+float32 dq
+float32 ddq
+float32 tau_est
+float32 q_raw
+float32 dq_raw
+float32 ddq_raw
+int8 temperature

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,10 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>hardware_interface</depend>
+  <depend>controller_manager</depend>
+  <depend>pluginlib</depend>
+  <exec_depend>robot_state_publisher</exec_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
@@ -28,5 +32,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <hardware_interface plugin="${prefix}/unitree_hardware_interface.xml"/>
   </export>
 </package>

--- a/src/serializers.cpp
+++ b/src/serializers.cpp
@@ -29,6 +29,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 
 #include <iostream>
 #include <unitree_ros/serializers.hpp>
+#include <unitree_ros/unitree_driver_lowlevel.hpp>
 
 void serialize(nav_msgs::msg::Odometry& msg, const odom_t odom) {
     msg.pose.pose.position.x = odom.pose.position.x;
@@ -109,4 +110,67 @@ void serialize(sensor_msgs::msg::JointState& msg,
             msg.effort[idx] = motor_states[idx].tauEst;
         }
     }
+}
+
+void serialize(unitree_ros::msg::MotorCmd& msg, const UnitreeDriverLowLevel::MotorCommand& cmd) {
+    msg.mode = cmd.mode;
+    msg.q = cmd.q;
+    msg.dq = cmd.dq;
+    msg.tau = cmd.tau;
+    msg.kp = cmd.kp;
+    msg.kd = cmd.kd;
+}
+
+void serialize(unitree_ros::msg::MotorState& msg, const UnitreeDriverLowLevel::MotorState& state) {
+    msg.mode = state.mode;
+    msg.q = state.q;
+    msg.dq = state.dq;
+    msg.ddq = state.ddq;
+    msg.tau_est = state.tauEst;
+    msg.q_raw = state.q_raw;
+    msg.dq_raw = state.dq_raw;
+    msg.ddq_raw = state.ddq_raw;
+    msg.temperature = state.temperature;
+}
+
+void serialize(unitree_ros::msg::ImuState& msg, const UnitreeDriverLowLevel::ImuState& imu) {
+    msg.quaternion = imu.quaternion;
+    msg.gyroscope = imu.gyroscope;
+    msg.accelerometer = imu.accelerometer;
+    msg.rpy = imu.rpy;
+    msg.temperature = imu.temperature;
+}
+
+void serialize(unitree_ros::msg::BmsState& msg, const UnitreeDriverLowLevel::BmsState& bms) {
+    msg.version_h = bms.version_h;
+    msg.version_l = bms.version_l;
+    msg.bms_status = bms.bms_status;
+    msg.soc = bms.SOC;
+    msg.current = bms.current;
+    msg.cycle = bms.cycle;
+    msg.bq_ntc = bms.BQ_NTC;
+    msg.mcu_ntc = bms.MCU_NTC;
+    msg.cell_vol = bms.cell_vol;
+}
+
+void serialize(unitree_ros::msg::LowCmd& msg, const UnitreeDriverLowLevel::LowCmd& cmd) {
+    msg.motor_cmd.resize(cmd.motorCmd.size());
+    for (size_t i = 0; i < cmd.motorCmd.size(); ++i) {
+        serialize(msg.motor_cmd[i], cmd.motorCmd[i]);
+    }
+    serialize(msg.bms, cmd.bms);
+    msg.wireless_remote = cmd.wirelessRemote;
+}
+
+void serialize(unitree_ros::msg::LowState& msg, const UnitreeDriverLowLevel::LowState& state) {
+    msg.motor_state.resize(state.motorState.size());
+    for (size_t i = 0; i < state.motorState.size(); ++i) {
+        serialize(msg.motor_state[i], state.motorState[i]);
+    }
+    serialize(msg.imu, state.imu);
+    serialize(msg.bms, state.bms);
+    msg.foot_force = state.footForce;
+    msg.foot_force_est = state.footForceEst;
+    msg.tick = state.tick;
+    msg.wireless_remote = state.wirelessRemote;
 }

--- a/src/unitree_driver_lowlevel.cpp
+++ b/src/unitree_driver_lowlevel.cpp
@@ -1,0 +1,217 @@
+#include <unistd.h>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+#include <unitree_ros/unitree_driver_lowlevel.hpp>
+
+UnitreeDriverLowLevel::UnitreeDriverLowLevel(std::string ip_addr, int target_port)
+    : ip_addr_(std::move(ip_addr)),
+      target_port_(target_port),
+      udp_connection_(UNITREE_LEGGED_SDK::LOWLEVEL, LOCAL_PORT, ip_addr_.c_str(), target_port_) {
+  std::cout << "Initializing Unitree LowLevel Driver..." << std::endl;
+  std::cout << "IP: " << ip_addr_ << ", Target Port: " << target_port_ << ", Local Port: " << LOCAL_PORT << std::endl;
+
+  sleep(2);
+
+  if (!is_connection_established_()) {
+    throw std::runtime_error("Connection to the robot could not be established, shutting down.");
+  }
+
+  init_cmd_data_();
+  connection_established_ = true;
+  std::cout << "LowLevel connection established!" << std::endl;
+
+  recv_state_thread_ = std::thread(&UnitreeDriverLowLevel::recv_low_state_loop_, this);
+  std::cout << "LowLevel state receiver thread started" << std::endl;
+}
+
+UnitreeDriverLowLevel::~UnitreeDriverLowLevel() {
+  recv_state_thread_stop_flag_ = true;
+  if (recv_state_thread_.joinable()) {
+    recv_state_thread_.join();
+  }
+  std::cout << "LowLevel driver shut down" << std::endl;
+}
+
+void UnitreeDriverLowLevel::init_cmd_data_() {
+  udp_connection_.InitCmdData(sdk_low_cmd_);
+
+  for (int i = 0; i < NUM_TOTAL_MOTORS; ++i) {
+    sdk_low_cmd_.motorCmd[i].mode = 0x00;
+    sdk_low_cmd_.motorCmd[i].q = 0.0f;
+    sdk_low_cmd_.motorCmd[i].dq = 0.0f;
+    sdk_low_cmd_.motorCmd[i].tau = 0.0f;
+    sdk_low_cmd_.motorCmd[i].Kp = 0.0f;
+    sdk_low_cmd_.motorCmd[i].Kd = 0.0f;
+  }
+}
+
+void UnitreeDriverLowLevel::recv_low_state_loop_() {
+  while (!recv_state_thread_stop_flag_) {
+    udp_connection_.Recv();
+    udp_connection_.GetRecv(sdk_low_state_);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+}
+
+bool UnitreeDriverLowLevel::is_connection_established_() {
+  std::cout << "Checking if robot connection is available..." << std::endl;
+  std::string cmd = "ping -c1 -s1 " + ip_addr_ + " > /dev/null 2>&1";
+  int exit_status = std::system(cmd.c_str());
+
+  if (exit_status == 0) {
+    std::cout << "Connection is available" << std::endl;
+    return true;
+  }
+  std::cout << "CONNECTION IS NOT AVAILABLE" << std::endl;
+  return false;
+}
+
+bool UnitreeDriverLowLevel::is_connection_established() const {
+  return connection_established_;
+}
+
+void UnitreeDriverLowLevel::send_low_cmd(const LowCmd& cmd) {
+  for (int i = 0; i < NUM_TOTAL_MOTORS; ++i) {
+    sdk_low_cmd_.motorCmd[i].mode = cmd.motorCmd[i].mode;
+    sdk_low_cmd_.motorCmd[i].q = cmd.motorCmd[i].q;
+    sdk_low_cmd_.motorCmd[i].dq = cmd.motorCmd[i].dq;
+    sdk_low_cmd_.motorCmd[i].tau = cmd.motorCmd[i].tau;
+    sdk_low_cmd_.motorCmd[i].Kp = cmd.motorCmd[i].kp;
+    sdk_low_cmd_.motorCmd[i].Kd = cmd.motorCmd[i].kd;
+  }
+
+  compute_crc_(sdk_low_cmd_);
+  udp_connection_.SetSend(sdk_low_cmd_);
+  udp_connection_.Send();
+}
+
+UnitreeDriverLowLevel::LowState UnitreeDriverLowLevel::get_low_state() const {
+  LowState state;
+  state.imu.quaternion = sdk_low_state_.imu.quaternion;
+  state.imu.gyroscope = sdk_low_state_.imu.gyroscope;
+  state.imu.accelerometer = sdk_low_state_.imu.accelerometer;
+  state.imu.rpy = sdk_low_state_.imu.rpy;
+  state.imu.temperature = sdk_low_state_.imu.temperature;
+
+  for (int i = 0; i < NUM_TOTAL_MOTORS; ++i) {
+    state.motorState[i].mode = sdk_low_state_.motorState[i].mode;
+    state.motorState[i].q = sdk_low_state_.motorState[i].q;
+    state.motorState[i].dq = sdk_low_state_.motorState[i].dq;
+    state.motorState[i].ddq = sdk_low_state_.motorState[i].ddq;
+    state.motorState[i].tauEst = sdk_low_state_.motorState[i].tauEst;
+    state.motorState[i].q_raw = sdk_low_state_.motorState[i].q_raw;
+    state.motorState[i].dq_raw = sdk_low_state_.motorState[i].dq_raw;
+    state.motorState[i].ddq_raw = sdk_low_state_.motorState[i].ddq_raw;
+    state.motorState[i].temperature = sdk_low_state_.motorState[i].temperature;
+  }
+
+  state.bms.version_h = sdk_low_state_.bms.version_h;
+  state.bms.version_l = sdk_low_state_.bms.version_l;
+  state.bms.bms_status = sdk_low_state_.bms.bms_status;
+  state.bms.SOC = sdk_low_state_.bms.SOC;
+  state.bms.current = sdk_low_state_.bms.current;
+  state.bms.cycle = sdk_low_state_.bms.cycle;
+  state.bms.BQ_NTC = sdk_low_state_.bms.BQ_NTC;
+  state.bms.MCU_NTC = sdk_low_state_.bms.MCU_NTC;
+  state.bms.cell_vol = sdk_low_state_.bms.cell_vol;
+
+  state.footForce = sdk_low_state_.footForce;
+  state.footForceEst = sdk_low_state_.footForceEst;
+  state.tick = sdk_low_state_.tick;
+  state.wirelessRemote = sdk_low_state_.wirelessRemote;
+
+  return state;
+}
+
+std::array<UnitreeDriverLowLevel::MotorState, 12> UnitreeDriverLowLevel::get_leg_joint_states() const {
+  std::array<MotorState, 12> joint_states;
+  for (int i = 0; i < NUM_LEG_JOINTS; ++i) {
+    int idx = leg_joint_indices_[i];
+    joint_states[i].mode = sdk_low_state_.motorState[idx].mode;
+    joint_states[i].q = sdk_low_state_.motorState[idx].q;
+    joint_states[i].dq = sdk_low_state_.motorState[idx].dq;
+    joint_states[i].ddq = sdk_low_state_.motorState[idx].ddq;
+    joint_states[i].tauEst = sdk_low_state_.motorState[idx].tauEst;
+    joint_states[i].q_raw = sdk_low_state_.motorState[idx].q_raw;
+    joint_states[i].dq_raw = sdk_low_state_.motorState[idx].dq_raw;
+    joint_states[i].ddq_raw = sdk_low_state_.motorState[idx].ddq_raw;
+    joint_states[i].temperature = sdk_low_state_.motorState[idx].temperature;
+  }
+  return joint_states;
+}
+
+void UnitreeDriverLowLevel::set_damping_mode() {
+  for (int i = 0; i < NUM_TOTAL_MOTORS; ++i) {
+    sdk_low_cmd_.motorCmd[i].mode = 0x00;
+    sdk_low_cmd_.motorCmd[i].q = 0.0f;
+    sdk_low_cmd_.motorCmd[i].dq = 0.0f;
+    sdk_low_cmd_.motorCmd[i].tau = 0.0f;
+    sdk_low_cmd_.motorCmd[i].Kp = 0.0f;
+    sdk_low_cmd_.motorCmd[i].Kd = 5.0f;
+  }
+  compute_crc_(sdk_low_cmd_);
+  udp_connection_.SetSend(sdk_low_cmd_);
+  udp_connection_.Send();
+}
+
+void UnitreeDriverLowLevel::set_position_mode(float kp, float kd) {
+  for (int i = 0; i < NUM_TOTAL_MOTORS; ++i) {
+    sdk_low_cmd_.motorCmd[i].mode = 0x0A;
+    sdk_low_cmd_.motorCmd[i].Kp = kp;
+    sdk_low_cmd_.motorCmd[i].Kd = kd;
+  }
+}
+
+uint32_t UnitreeDriverLowLevel::crc32_core_(const uint32_t* ptr, uint32_t len) {
+  static const uint32_t crc_table[256] = {
+    0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,
+    0x0EDB8832, 0x79DCB8A4, 0xE0D5E91E, 0x97D2D988, 0x09B64C2B, 0x7EB17CBD, 0xE7B82D07, 0x90BF1D91,
+    0x1DB71064, 0x6AB020F2, 0xF3B97148, 0x84BE41DE, 0x1ADAD47D, 0x6DDDE4EB, 0xF4D4B551, 0x83D385C7,
+    0x136C9856, 0x646BA8C0, 0xFD62F97A, 0x8A65C9EC, 0x14015C4F, 0x63066CD9, 0xFA0F3D63, 0x8D080DF5,
+    0x3B6E20C8, 0x4C69105E, 0xD56041E4, 0xA2677172, 0x3C03E4D1, 0x4B04D447, 0xD20D85FD, 0xA50AB56B,
+    0x35B5A8FA, 0x42B2986C, 0xDBBBC9D6, 0xACBCF940, 0x32D86CE3, 0x45DF5C75, 0xDCD60DCF, 0xABD13D59,
+    0x26D930AC, 0x51DE003A, 0xC8D75180, 0xBFD06116, 0x21B4F4B5, 0x56B3C423, 0xCFBA9599, 0xB8BDA50F,
+    0x2802B89E, 0x5F058808, 0xC60CD9B2, 0xB10BE924, 0x2F6F7C87, 0x58684C11, 0xC1611DAB, 0xB6662D3D,
+    0x76DC4190, 0x01DB7106, 0x98D220BC, 0xEFD5102A, 0x71B18589, 0x06B6B51F, 0x9FBFE4A5, 0xE8B8D433,
+    0x7807C9A2, 0x0F00F934, 0x9609A88E, 0xE10E9818, 0x7F6A0DBB, 0x086D3D2D, 0x91646C97, 0xE6635C01,
+    0x6B6B51F4, 0x1C6C6162, 0x856530D8, 0xF262004E, 0x6C0695ED, 0x1B01A57B, 0x8208F4C1, 0xF50FC457,
+    0x65B0D9C6, 0x12B7E950, 0x8BBEB8EA, 0xFCB9887C, 0x62DD1DDF, 0x15DA2D49, 0x8CD37CF3, 0xFBD44C65,
+    0x4DB26158, 0x3AB551CE, 0xA3BC0074, 0xD4BB30E2, 0x4ADFA541, 0x3DD895D7, 0xA4D1C46D, 0xD3D6F4FB,
+    0x4369E96A, 0x346ED9FC, 0xAD678846, 0xDA60B8D0, 0x44042D73, 0x33031DE5, 0xAA0A4C5F, 0xDD0D7CC9,
+    0x5005713C, 0x270241AA, 0xBE0B1010, 0xC90C2086, 0x5768B525, 0x206F85B3, 0xB966D409, 0xCE61E49F,
+    0x5EDEF90E, 0x29D9C998, 0xB0D09822, 0xC7D7A8B4, 0x59B33D17, 0x2EB40D81, 0xB7BD5C3B, 0xC0BA6CAD,
+    0xEDB88320, 0x9ABFB3B6, 0x03B6E20C, 0x74B1D29A, 0xEAD54739, 0x9DD277AF, 0x04DB2615, 0x73DC1683,
+    0xE3630B12, 0x94643B84, 0x0D6D6A3E, 0x7A6A5AA8, 0xE40ECF0B, 0x9309FF9D, 0x0A00AE27, 0x7D079EB1,
+    0xF00F9344, 0x8708A3D2, 0x1E01F268, 0x6906C2FE, 0xF762575D, 0x806567CB, 0x196C3671, 0x6E6B06E7,
+    0xFED41B76, 0x89D32BE0, 0x10DA7A5A, 0x67DD4ACC, 0xF9B9DF6F, 0x8EBEEFF9, 0x17B7BE43, 0x60B08ED5,
+    0xD6D6A3E8, 0xA1D1937E, 0x38D8C2C4, 0x4FDFF252, 0xD1BB67F1, 0xA6BC5767, 0x3FB506DD, 0x48B2364B,
+    0xD80D2BDA, 0xAF0A1B4C, 0x36034AF6, 0x41047A60, 0xDF60EFC3, 0xA867DF55, 0x316E8EEF, 0x4669BE79,
+    0xCB61B38C, 0xBC66831A, 0x256FD2A0, 0x5268E236, 0xCC0C7795, 0xBB0B4703, 0x220216B9, 0x5505262F,
+    0xC5BA3BBE, 0xB2BD0B28, 0x2BB45A92, 0x5CB36A04, 0xC2D7FFA7, 0xB5D0CF31, 0x2CD99E8B, 0x5BDEAE1D,
+    0x9B64C2B0, 0xEC63F226, 0x756AA39C, 0x026D930A, 0x9C0906A9, 0xEB0E363F, 0x72076785, 0x05005713,
+    0x95BF4A82, 0xE2B87A14, 0x7BB12BAE, 0x0CB61B38, 0x92D28E9B, 0xE5D5BE0D, 0x7CDCEFB7, 0x0BDBDF21,
+    0x86D3D2D4, 0xF1D4E242, 0x68DDB3F8, 0x1FDA836E, 0x81BE16CD, 0xF6B9265B, 0x6FB077E1, 0x18B74777,
+    0x88085AE6, 0xFF0F6A70, 0x66063BCA, 0x11010B5C, 0x8F659EFF, 0xF862AE69, 0x616BFFD3, 0x166CCF45,
+    0xA00AE278, 0xD70DD2EE, 0x4E048354, 0x3903B3C2, 0xA7672661, 0xD06016F7, 0x4969474D, 0x3E6E77DB,
+    0xAED16A4A, 0xD9D65ADC, 0x40DF0B66, 0x37D83BF0, 0xA9BCAE53, 0xDEBB9EC5, 0x47B2CF7F, 0x30B5FFE9,
+    0xBDBDF21C, 0xCABAC28A, 0x53B39330, 0x24B4A3A6, 0xBAD03605, 0xCDD70693, 0x54DE5729, 0x23D967BF,
+    0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94, 0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D,
+};
+
+  uint32_t crc = 0xFFFFFFFF;
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(ptr);
+  for (uint32_t i = 0; i < len * 4; ++i) {
+    crc = crc_table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+  }
+  return crc ^ 0xFFFFFFFF;
+}
+
+void UnitreeDriverLowLevel::compute_crc_(UNITREE_LEGGED_SDK::LowCmd& cmd) {
+  cmd.crc = 0;
+  uint32_t* data = reinterpret_cast<uint32_t*>(&cmd);
+  int len = (sizeof(UNITREE_LEGGED_SDK::LowCmd) - 4) / 4;
+  cmd.crc = crc32_core_(data, len);
+}

--- a/src/unitree_hardware_interface.cpp
+++ b/src/unitree_hardware_interface.cpp
@@ -1,0 +1,153 @@
+#include <unitree_ros/unitree_hardware_interface.hpp>
+#include <rclcpp/logging.hpp>
+
+namespace unitree_ros
+{
+
+hardware_interface::CallbackReturn UnitreeHardwareInterface::on_init(
+  const hardware_interface::HardwareInfo& info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS) {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Initializing Unitree Hardware Interface...");
+
+  for (const auto& param : info.hardware_parameters) {
+    if (param.first == "robot_ip") {
+      robot_ip_ = param.second;
+    } else if (param.first == "robot_port") {
+      robot_port_ = std::stoi(param.second);
+    } else if (param.first == "default_kp") {
+      default_kp_ = std::stof(param.second);
+    } else if (param.first == "default_kd") {
+      default_kd_ = std::stof(param.second);
+    }
+  }
+
+  hw_positions_.resize(joint_names_.size(), 0.0);
+  hw_velocities_.resize(joint_names_.size(), 0.0);
+  hw_efforts_.resize(joint_names_.size(), 0.0);
+  hw_position_commands_.resize(joint_names_.size(), 0.0);
+  hw_velocity_commands_.resize(joint_names_.size(), 0.0);
+  hw_effort_commands_.resize(joint_names_.size(), 0.0);
+
+  try {
+    driver_ = std::make_unique<UnitreeDriverLowLevel>(robot_ip_, robot_port_);
+    RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Driver connected successfully");
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(rclcpp::get_logger("UnitreeHardwareInterface"), "Failed to connect: %s", e.what());
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  driver_->set_position_mode(default_kp_, default_kd_);
+
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Hardware interface initialized!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> UnitreeHardwareInterface::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i) {
+    state_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_POSITION, &hw_positions_[i]);
+    state_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_VELOCITY, &hw_velocities_[i]);
+    state_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_EFFORT, &hw_efforts_[i]);
+  }
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> UnitreeHardwareInterface::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i) {
+    command_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_POSITION, &hw_position_commands_[i]);
+    command_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_VELOCITY, &hw_velocity_commands_[i]);
+    command_interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_EFFORT, &hw_effort_commands_[i]);
+  }
+  return command_interfaces;
+}
+
+hardware_interface::CallbackReturn UnitreeHardwareInterface::on_activate(
+  const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Activating hardware interface...");
+  
+  for (size_t i = 0; i < joint_names_.size(); ++i) {
+    hw_position_commands_[i] = hw_positions_[i];
+    hw_velocity_commands_[i] = 0.0;
+    hw_effort_commands_[i] = 0.0;
+  }
+
+  driver_->set_position_mode(default_kp_, default_kd_);
+  
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Hardware interface activated!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn UnitreeHardwareInterface::on_deactivate(
+  const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Deactivating hardware interface...");
+  
+  driver_->set_damping_mode();
+  
+  RCLCPP_INFO(rclcpp::get_logger("UnitreeHardwareInterface"), "Hardware interface deactivated!");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type UnitreeHardwareInterface::read(
+  const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+  auto leg_states = driver_->get_leg_joint_states();
+  
+  for (size_t i = 0; i < joint_names_.size(); ++i) {
+    int sdk_idx = joint_to_sdk_index_[i];
+    hw_positions_[i] = leg_states[sdk_idx].q;
+    hw_velocities_[i] = leg_states[sdk_idx].dq;
+    hw_efforts_[i] = leg_states[sdk_idx].tauEst;
+  }
+
+  if (first_read_) {
+    for (size_t i = 0; i < joint_names_.size(); ++i) {
+      hw_position_commands_[i] = hw_positions_[i];
+    }
+    first_read_ = false;
+  }
+
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type UnitreeHardwareInterface::write(
+  const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
+{
+  UnitreeDriverLowLevel::LowCmd cmd{};
+  
+  for (int i = 0; i < 20; ++i) {
+    cmd.motorCmd[i].mode = 0x00;
+    cmd.motorCmd[i].q = 0.0f;
+    cmd.motorCmd[i].dq = 0.0f;
+    cmd.motorCmd[i].tau = 0.0f;
+    cmd.motorCmd[i].kp = 0.0f;
+    cmd.motorCmd[i].kd = 0.0f;
+  }
+
+  for (size_t i = 0; i < joint_names_.size(); ++i) {
+    int sdk_idx = joint_to_sdk_index_[i];
+    cmd.motorCmd[sdk_idx].mode = 0x0A;
+    cmd.motorCmd[sdk_idx].q = static_cast<float>(hw_position_commands_[i]);
+    cmd.motorCmd[sdk_idx].dq = static_cast<float>(hw_velocity_commands_[i]);
+    cmd.motorCmd[sdk_idx].tau = static_cast<float>(hw_effort_commands_[i]);
+    cmd.motorCmd[sdk_idx].kp = default_kp_;
+    cmd.motorCmd[sdk_idx].kd = default_kd_;
+  }
+
+  driver_->send_low_cmd(cmd);
+
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace unitree_ros
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(unitree_ros::UnitreeHardwareInterface, hardware_interface::SystemInterface)

--- a/src/unitree_lowlevel_node.cpp
+++ b/src/unitree_lowlevel_node.cpp
@@ -1,0 +1,135 @@
+#include <rclcpp/rclcpp.hpp>
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <unitree_ros/msg/low_state.hpp>
+#include <unitree_ros/msg/low_cmd.hpp>
+#include <unitree_ros/msg/motor_cmd.hpp>
+#include <unitree_ros/msg/bms_state.hpp>
+#include <unitree_ros/msg/imu_state.hpp>
+#include <unitree_ros/unitree_driver_lowlevel.hpp>
+#include <unitree_ros/serializers.hpp>
+
+class UnitreeLowLevelNode : public rclcpp::Node
+{
+public:
+  UnitreeLowLevelNode() : Node("unitree_lowlevel_node")
+  {
+    declare_parameter<std::string>("robot_ip", "192.168.123.161");
+    declare_parameter<int>("robot_port", 8082);
+    declare_parameter<double>("publish_rate", 500.0);
+    declare_parameter<std::string>("joint_states_topic", "joint_states");
+    declare_parameter<std::string>("low_state_topic", "low_state");
+    declare_parameter<std::string>("low_cmd_topic", "low_cmd");
+
+    get_parameter("robot_ip", robot_ip_);
+    get_parameter("robot_port", robot_port_);
+    get_parameter("publish_rate", publish_rate_);
+    get_parameter("joint_states_topic", joint_states_topic_);
+    get_parameter("low_state_topic", low_state_topic_);
+    get_parameter("low_cmd_topic", low_cmd_topic_);
+
+    RCLCPP_INFO(get_logger(), "Initializing low-level driver...");
+    
+    try {
+      driver_ = std::make_unique<UnitreeDriverLowLevel>(robot_ip_, robot_port_);
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR(get_logger(), "Failed to initialize driver: %s", e.what());
+      return;
+    }
+
+    joint_states_pub_ = create_publisher<sensor_msgs::msg::JointState>(
+      joint_states_topic_, rclcpp::QoS(1).reliable());
+    
+    low_state_pub_ = create_publisher<unitree_ros::msg::LowState>(
+      low_state_topic_, rclcpp::QoS(1).reliable());
+
+    low_cmd_sub_ = create_subscription<unitree_ros::msg::LowCmd>(
+      low_cmd_topic_, rclcpp::QoS(1).best_effort(),
+      std::bind(&UnitreeLowLevelNode::low_cmd_callback_, this, std::placeholders::_1));
+
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(static_cast<int>(1000.0 / publish_rate_)),
+      std::bind(&UnitreeLowLevelNode::publish_state_, this));
+
+    initialized_ = true;
+    RCLCPP_INFO(get_logger(), "Low-level node started at %.1f Hz", publish_rate_);
+  }
+
+  bool is_initialized() const { return initialized_; }
+
+private:
+  void low_cmd_callback_(const unitree_ros::msg::LowCmd::SharedPtr msg)
+  {
+    UnitreeDriverLowLevel::LowCmd cmd{};
+    size_t n = std::min<size_t>(msg->motor_cmd.size(), 20);
+    for (size_t i = 0; i < n; ++i) {
+      cmd.motorCmd[i].mode = msg->motor_cmd[i].mode;
+      cmd.motorCmd[i].q = msg->motor_cmd[i].q;
+      cmd.motorCmd[i].dq = msg->motor_cmd[i].dq;
+      cmd.motorCmd[i].tau = msg->motor_cmd[i].tau;
+      cmd.motorCmd[i].kp = msg->motor_cmd[i].kp;
+      cmd.motorCmd[i].kd = msg->motor_cmd[i].kd;
+    }
+    driver_->send_low_cmd(cmd);
+  }
+
+  void publish_state_()
+  {
+    auto now = this->now();
+    
+    auto leg_states = driver_->get_leg_joint_states();
+    
+    sensor_msgs::msg::JointState joint_msg;
+    joint_msg.header.stamp = now;
+    joint_msg.name = {"FR_hip_joint", "FR_thigh_joint", "FR_calf_joint",
+                      "FL_hip_joint", "FL_thigh_joint", "FL_calf_joint",
+                      "RR_hip_joint", "RR_thigh_joint", "RR_calf_joint",
+                      "RL_hip_joint", "RL_thigh_joint", "RL_calf_joint"};
+    joint_msg.position.resize(12);
+    joint_msg.velocity.resize(12);
+    joint_msg.effort.resize(12);
+    
+    for (size_t i = 0; i < 12; ++i) {
+      joint_msg.position[i] = leg_states[i].q;
+      joint_msg.velocity[i] = leg_states[i].dq;
+      joint_msg.effort[i] = leg_states[i].tauEst;
+    }
+    joint_states_pub_->publish(joint_msg);
+
+    auto low_state = driver_->get_low_state();
+    unitree_ros::msg::LowState low_state_msg;
+    low_state_msg.stamp = now;
+    serialize(low_state_msg, low_state);
+    low_state_pub_->publish(low_state_msg);
+  }
+
+  std::string robot_ip_;
+  int robot_port_;
+  double publish_rate_;
+  std::string joint_states_topic_;
+  std::string low_state_topic_;
+  std::string low_cmd_topic_;
+
+  std::unique_ptr<UnitreeDriverLowLevel> driver_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_states_pub_;
+  rclcpp::Publisher<unitree_ros::msg::LowState>::SharedPtr low_state_pub_;
+  rclcpp::Subscription<unitree_ros::msg::LowCmd>::SharedPtr low_cmd_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  bool initialized_ = false;
+};
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<UnitreeLowLevelNode>();
+  if (!node->is_initialized()) {
+    rclcpp::shutdown();
+    return 1;
+  }
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/unitree_hardware_interface.xml
+++ b/unitree_hardware_interface.xml
@@ -1,0 +1,10 @@
+<library path="unitree_hardware_interface_lib">
+  <class name="unitree_ros/UnitreeHardwareInterface"
+         type="unitree_ros::UnitreeHardwareInterface"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      ROS2 control hardware interface for the Unitree Go1 quadruped robot using the
+      unitree_legged_sdk low-level (LOWLEVEL) UDP interface.
+    </description>
+  </class>
+</library>


### PR DESCRIPTION
> [!WARNING]
> This PR contains edits done using `opencode` with the `DeepSeek v4 Flash` model. I will let you know when I am done testing this code on the actual hardware. Meanwhile, if anyone is interested in testing the code on their own hardware, please feel free to let me know about errors or issues faced.

# Low-level joint control for the Unitree Go1 via ROS 2 Control

> [!IMPORTANT]
> This PR solves issue #27 

Adds low-level (LOWLEVEL UDP) joint control to the `unitree_ros` package, exposed through the standard ROS 2 Control stack (`ros2_control_node` + `joint_trajectory_controller`), so no custom controllers are required. Targets ROS 2 **Jazzy** and **Kilted**.

## What's included

### ros2_control hardware interface
- `unitree_ros::UnitreeHardwareInterface` — a `hardware_interface::SystemInterface` plugin loaded by the stock `controller_manager/ros2_control_node`.
- Exports per-joint `position` / `velocity` / `effort` command **and** state interfaces for all 12 Go1 leg joints.
- PD gains are configured via the `default_kp` / `default_kd` hardware params (defaults `60.0` / `3.0`); control law `τ = kp·(q_des − q) + kd·(dq_des − dq) + τ_ff`.
- Fail-fast `on_init`: refuses to initialize if the robot IP is unreachable (ping check).

### Low-level driver
- `UnitreeDriverLowLevel` wraps the `unitree_legged_sdk` v3.5.1 UDP LOWLEVEL interface (500 Hz), with a dedicated receive thread, damping/position modes, and correct CRC32 on `LowCmd`.
- Register names: `FR/FL/RR/RL_{hip,thigh,calf}_joint` ↔ SDK indices 0–11 (hip ±1.047 rad, thigh −0.663…2.966 rad, calf −2.721…−0.837 rad).

### Launch / config
- `lowlevel_ros2_control.launch.py` — generates a minimal URDF inline (links + revolute joints with Go1 limits + the `<ros2_control>` block), runs `robot_state_publisher`, `ros2_control_node`, and spawns `joint_state_broadcaster` + `joint_trajectory_controller`. Parameters: `robot_ip`, `robot_port`, `default_kp`, `default_kd`.
- `lowlevel.launch.py` — standalone debug node publishing `/joint_states` + `/low_state` and subscribing to `/low_cmd`.
- `config/unitree_ros_control.yaml` — controller manager config (500 Hz update rate).
- Custom msgs (`LowCmd`, `LowState`, `MotorCmd`, `MotorState`, `ImuState`) for debugging only; control goes through the standard ROS 2 interfaces.

### Docs
- `LOW_LEVEL_CONTROL_README.md` — safety procedure, three control methods, joint mapping, config reference, and troubleshooting.

## Verification

Both distros build and run inside Docker:
```bash
docker build --network=host -f docker/jazzy/Dockerfile -t unitree_ros:jazzy .
docker build --network=host -f docker/kilted/Dockerfile -t unitree_ros:kilted .
```

- `colcon build` passes on Jazzy and Kilted.
- Plugin discovery + instantiation verified with a `pluginlib::ClassLoader<hardware_interface::SystemInterface>` test on both distros.
- Kilted end-to-end: controller manager loads the plugin, registers joint limiters for all 12 joints from the URDF, `on_init` opens the UDP socket (port 8090); it then stops with `Failed to connect` only because no robot is attached — expected fail-fast behavior.
- Hardware is **not** connected in this environment, so no motor commands were exercised against the real robot.

## Notable fixes required for the builds to work
- `pluginlib_export_plugin_description_file(hardware_interface ...)` — the category must be `hardware_interface` (not the package name) or the plugin is never discovered.
- The controller manager on Jazzy/Kilted reads `robot_description` from the `/robot_description` **topic**, so the launch publishes it via `robot_state_publisher`.
- The URDF must contain real `<joint>` elements with `<limit>` for `enforce_command_limits` (also enables command limiting as a safety feature).
- `.msg` files must use short type forms (`unitree_ros/MotorCmd`, not `unitree_ros/msg/MotorCmd`).
- Dockerfiles copy `unitree_hardware_interface.xml` and run `apt-get update` in the rosdep step to avoid stale cached apt indexes.

## Known issue (Jazzy only, upstream)
`ros2_control_node` crashes at startup on Jazzy:
```
symbol lookup error: libpal_statistics_msgs__rosidl_typesupport_fastrtps_cpp.so:
  undefined symbol: _ZN8eprosima7fastcdr3Cdr9serializeEj
```
`pal_statistics_msgs` 2.7.0 was built against a newer Fast CDR ABI than the installed `ros-jazzy-fastcdr` 2.2.5 (packaging skew in the current Jazzy apt repo; reproduces with a stock node, no Unitree code involved). Kilted is unaffected. Tracked in ros2/rosidl_typesupport_fastrtps#126 and eProsima/Fast-CDR#266.

## To test on real hardware
1. Suspend/harness the robot; `L2+A` to sit; `L1+L2+Start` for low-level mode.
2. `ros2 launch unitree_ros lowlevel_ros2_control.launch.py robot_ip:=192.168.123.161`
3. Send a `JointTrajectory` to `/joint_trajectory_controller/joint_trajectory`.
